### PR TITLE
Fixed empty payloads

### DIFF
--- a/src/main/python/geventwebsocket/websocket.py
+++ b/src/main/python/geventwebsocket/websocket.py
@@ -200,15 +200,15 @@ class WebSocket(object):
             raise ProtocolError
 
         if not header.length:
-            return header, ''
+            return header, b''
 
         try:
             payload = self.raw_read(header.length)
         except error:
-            payload = ''
+            payload = b''
         except Exception:
             # TODO log out this exception
-            payload = ''
+            payload = b''
 
         if len(payload) != header.length:
             raise WebSocketError('Unexpected EOF reading frame payload')


### PR DESCRIPTION
It seems like payloads are always bytes objects, but in the case of empty payloads a str was returned, breaking concatenation.

To test, make a simple "echo" WS client and send an empty string.