### PR TITLE
Wrong empty default payloads and mask (str/bytes) in read_frame and send_frame

### DIFF
--- a/src/main/python/geventwebsocket/websocket.py
+++ b/src/main/python/geventwebsocket/websocket.py
@@ -200,15 +200,15 @@ class WebSocket(object):
             raise ProtocolError
 
         if not header.length:
-            return header, ''
+            return header, b''
 
         try:
             payload = self.raw_read(header.length)
         except error:
-            payload = ''
+            payload = b''
         except Exception:
             # TODO log out this exception
-            payload = ''
+            payload = b''
 
         if len(payload) != header.length:
             raise WebSocketError('Unexpected EOF reading frame payload')
@@ -322,7 +322,7 @@ class WebSocket(object):
         elif opcode == self.OPCODE_BINARY:
             message = bytes(message)
 
-        header = Header.encode_header(True, opcode, '', len(message), 0)
+        header = Header.encode_header(True, opcode, b'', len(message), 0)
 
         try:
             self.raw_write(header + message)

--- a/src/unittest/python/ws_tests.py
+++ b/src/unittest/python/ws_tests.py
@@ -97,12 +97,14 @@ class WSTests(TestCase):
 
     def test_low_level_echo(self):
         data = []
+        data.append("")
         data.append("0123456789")
         data.append("0123456789" * 20)
         data.append("0123456789" * 2000)
         data.append("0123456789" * 20000)
         data.append("0123456789" * 200000)
 
+        data.append(b"")
         data.append(b"0123456789")
         data.append(b"0123456789" * 20)
         data.append(b"0123456789" * 2000)
@@ -180,12 +182,14 @@ class WSTests(TestCase):
 
     def test_high_level_echo(self):
         data = []
+        data.append("")
         data.append("0123456789")
         data.append("0123456789" * 20)
         data.append("0123456789" * 2000)
         data.append("0123456789" * 20000)
         data.append("0123456789" * 200000)
 
+        data.append(b"")
         data.append(b"0123456789")
         data.append(b"0123456789" * 20)
         data.append(b"0123456789" * 2000)


### PR DESCRIPTION
fixes #24, #25